### PR TITLE
feat: add support for custom imap servers

### DIFF
--- a/pkg/common/ids.go
+++ b/pkg/common/ids.go
@@ -2,8 +2,8 @@ package common
 
 import (
 	"fmt"
-	"strings"
 	"maunium.net/go/mautrix/bridgev2/networkid"
+	"strings"
 )
 
 // EmailToGhostID converts an email address to a Matrix ghost user ID in a single, canonical place.
@@ -19,14 +19,14 @@ func EmailToGhostID(email string) networkid.UserID {
 func RecoverToError(errCh chan<- error) {
 	if r := recover(); r != nil {
 		var err error
-		
+
 		// Preserve original error if the panic value is already an error
 		if panicErr, ok := r.(error); ok {
 			err = fmt.Errorf("panic recovered: %w", panicErr)
 		} else {
 			err = fmt.Errorf("panic recovered: %v", r)
 		}
-		
+
 		// Safe send - non-blocking to prevent deadlocks and handle closed/nil channels
 		if errCh != nil {
 			select {

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -22,13 +22,13 @@ import (
 type ClientConfig struct {
 	// Registration wait time before checking if client connected
 	RegistrationWaitTime time.Duration
-	
+
 	// Reconnection sleep time to allow server-side cleanup
 	ReconnectionSleepTime time.Duration
-	
+
 	// Periodic sync interval
 	PeriodicSyncInterval time.Duration
-	
+
 	// Minimum time between sync operations (throttling)
 	SyncThrottleTime time.Duration
 }
@@ -87,7 +87,7 @@ var (
 // extractEmailCredentials extracts email and username from login metadata or login ID
 func (ec *EmailConnector) extractEmailCredentials(login *bridgev2.UserLogin) (string, string, error) {
 	var email, username string
-	
+
 	// Extract login metadata with proper error handling
 	if login.Metadata != nil {
 		if loginMetadata, ok := login.Metadata.(*EmailLoginMetadata); ok && loginMetadata.Email != "" {
@@ -133,12 +133,14 @@ func (ec *EmailConnector) loadAccountCredentials(ctx context.Context, userMXID, 
 }
 
 // createIMAPClient creates and configures the IMAP client
-func (ec *EmailConnector) createIMAPClient(emailClient *EmailClient, login *bridgev2.UserLogin) error {
+func (ec *EmailConnector) createIMAPClient(emailClient *EmailClient, login *bridgev2.UserLogin, account *EmailAccount) error {
 	logger := login.Log.With().Str("component", "imap").Logger()
+	connectionOverrides := buildConnectionOverrides(emailClient.Email, account)
 	imapClient, err := imap.NewClient(
 		emailClient.Email,
 		emailClient.Username,
 		emailClient.Password,
+		connectionOverrides,
 		login,
 		&logger,
 		ec.Config.Logging.Sanitized,
@@ -160,6 +162,58 @@ func (ec *EmailConnector) createIMAPClient(emailClient *EmailClient, login *brid
 	}
 
 	return nil
+}
+
+func buildConnectionOverrides(email string, account *EmailAccount) *imap.ConnectionOverrides {
+	if account == nil {
+		return nil
+	}
+
+	host := strings.TrimSpace(account.Host)
+	port := account.Port
+	tlsValue := account.TLS
+
+	parts := strings.Split(email, "@")
+	if len(parts) != 2 {
+		return nil
+	}
+
+	domain := strings.ToLower(parts[1])
+	defaultHost := fmt.Sprintf("imap.%s", domain)
+	defaultPort := 993
+	defaultTLS := true
+
+	if provider, ok := imap.CommonProviders[domain]; ok {
+		defaultHost = provider.Host
+		defaultPort = provider.Port
+		defaultTLS = provider.TLS
+	}
+
+	hostDiff := host != "" && !strings.EqualFold(host, defaultHost)
+	portDiff := port > 0 && port != defaultPort
+	tlsDiff := tlsValue != defaultTLS
+
+	if !hostDiff && !portDiff && !tlsDiff {
+		return nil
+	}
+
+	overrides := &imap.ConnectionOverrides{}
+	if hostDiff && host != "" {
+		overrides.Host = host
+	}
+	if portDiff && port > 0 {
+		overrides.Port = port
+	}
+	if tlsDiff {
+		tlsCopy := tlsValue
+		overrides.TLS = &tlsCopy
+	}
+
+	if overrides.Host == "" && overrides.Port == 0 && overrides.TLS == nil {
+		return nil
+	}
+
+	return overrides
 }
 
 // startClientConnections starts the client connection and registration processes
@@ -187,7 +241,7 @@ func (ec *EmailConnector) startClientConnections(emailClient *EmailClient, login
 func (ec *EmailConnector) LoadUserLogin(ctx context.Context, login *bridgev2.UserLogin) error {
 	// Create client lifecycle context that survives beyond this function
 	clientCtx, clientCancel := context.WithCancel(context.Background())
-	
+
 	// Create email client for this login
 	emailClient := &EmailClient{
 		Main:      ec,
@@ -196,7 +250,7 @@ func (ec *EmailConnector) LoadUserLogin(ctx context.Context, login *bridgev2.Use
 		cancel:    clientCancel,
 		config:    DefaultClientConfig(),
 	}
-	
+
 	// Initialize state coordinator
 	emailClient.stateCoordinator = coordinator.NewStateCoordinator(login, &ec.Bridge.Log)
 	login.Client = emailClient
@@ -217,7 +271,7 @@ func (ec *EmailConnector) LoadUserLogin(ctx context.Context, login *bridgev2.Use
 	emailClient.Password = account.Password
 
 	// Create IMAP client
-	if err := ec.createIMAPClient(emailClient, login); err != nil {
+	if err := ec.createIMAPClient(emailClient, login, account); err != nil {
 		return err
 	}
 
@@ -366,11 +420,11 @@ func (ec *EmailClient) Stop(ctx context.Context) {
 func (ec *EmailClient) startIDLEWithRetry() error {
 	// Get IMAP timeout configuration for timeout protection
 	timeoutConfig := reliability.IMAPTimeouts()
-	
+
 	// Add timeout for the entire IDLE startup sequence
 	timeoutCtx, cancel := context.WithTimeout(ec.ctx, timeoutConfig.Command)
 	defer cancel()
-	
+
 	return reliability.RetryWithBackoff(timeoutCtx, reliability.IDLEStartupRetryConfig(), func() error {
 		// Test connection health first
 		if err := ec.IMAPClient.TestConnection(); err != nil {
@@ -378,16 +432,16 @@ func (ec *EmailClient) startIDLEWithRetry() error {
 			// Let the retry system handle connection recovery - this will trigger reconnectIMAPClient
 			return err
 		}
-		
+
 		// Attempt to start IDLE
 		if err := ec.IMAPClient.StartIDLE(); err != nil {
 			// Let the retry system categorize and decide whether to retry
 			// This includes IDLE conflicts, server errors, and network issues
 			ec.UserLogin.Log.Debug().Err(err).Msg("IDLE startup failed, letting retry system handle recovery")
-			
+
 			// For IDLE conflicts, force reconnection before next retry
-			if strings.Contains(strings.ToLower(err.Error()), "idle already") || 
-			   strings.Contains(strings.ToLower(err.Error()), "already running") {
+			if strings.Contains(strings.ToLower(err.Error()), "idle already") ||
+				strings.Contains(strings.ToLower(err.Error()), "already running") {
 				if reconErr := ec.reconnectIMAPClient(); reconErr != nil {
 					ec.UserLogin.Log.Warn().Err(reconErr).Msg("Failed to reconnect during IDLE conflict recovery")
 					// Return original error, not reconnection error, for retry system categorization
@@ -395,10 +449,10 @@ func (ec *EmailClient) startIDLEWithRetry() error {
 					ec.UserLogin.Log.Debug().Msg("Reconnected successfully to clear IDLE conflict")
 				}
 			}
-			
+
 			return err
 		}
-		
+
 		ec.UserLogin.Log.Info().Msg("IDLE started successfully")
 		return nil
 	})
@@ -469,7 +523,7 @@ func (ec *EmailClient) performPeriodicSync(ctx context.Context) {
 	timeoutConfig := reliability.IMAPTimeouts()
 	timeoutCtx, cancel := context.WithTimeout(ctx, timeoutConfig.Command)
 	defer cancel()
-	
+
 	var err error
 	func() {
 		// Capture IMAP client reference safely to prevent nil pointer panic

--- a/pkg/connector/config.go
+++ b/pkg/connector/config.go
@@ -11,11 +11,11 @@ var ExampleConfig string
 
 type Config struct {
 	// Top-level blocks to match example-config.yaml structure
-	IMAP       IMAPConfig        `yaml:"imap"`
-	Logging    LoggingConfig     `yaml:"logging"`
-	Processing ProcessingConfig  `yaml:"email_processing"`
+	IMAP       IMAPConfig       `yaml:"imap"`
+	Logging    LoggingConfig    `yaml:"logging"`
+	Processing ProcessingConfig `yaml:"email_processing"`
 	// Keep Network for internal use but don't map to YAML
-	Network    NetworkConfig     `yaml:"-"`
+	Network NetworkConfig `yaml:"-"`
 }
 
 type NetworkConfig struct {
@@ -43,24 +43,24 @@ const DefaultMaxUploadBytes = 25 * 1024 * 1024 // 25 MiB
 
 type ProcessingConfig struct {
 	// Maximum size in bytes for a single media upload. Set 0 to disable the check.
-	MaxUploadBytes int  `yaml:"max_upload_bytes"`
+	MaxUploadBytes int `yaml:"max_upload_bytes"`
 	// If true, attempt gzip for oversized original HTML/text bodies before attaching.
 	GzipLargeBodies bool `yaml:"gzip_large_bodies"`
 }
 
 func upgradeConfig(helper up.Helper) {
 	// Copy all keys that exist in the embedded example (pkg/connector/example-config.yaml)
-	
+
 	// IMAP configuration
 	helper.Copy(up.Int, "imap", "default_timeout")
-	helper.Copy(up.Int, "imap", "startup_backfill_seconds") 
+	helper.Copy(up.Int, "imap", "startup_backfill_seconds")
 	helper.Copy(up.Int, "imap", "startup_backfill_max")
 	helper.Copy(up.Int, "imap", "initial_idle_timeout_seconds")
-	
+
 	// Email processing configuration
 	helper.Copy(up.Int, "email_processing", "max_upload_bytes")
 	helper.Copy(up.Bool, "email_processing", "gzip_large_bodies")
-	
+
 	// Logging configuration
 	helper.Copy(up.Bool, "logging", "sanitized")
 	helper.Copy(up.Str, "logging", "pseudonym_secret")
@@ -69,7 +69,7 @@ func upgradeConfig(helper up.Helper) {
 func (ec *EmailConnector) GetConfig() (string, any, up.Upgrader) {
 	return ExampleConfig, &ec.Config, &up.StructUpgrader{
 		SimpleUpgrader: up.SimpleUpgrader(upgradeConfig),
-		Blocks: [][]string{},
-		Base: ExampleConfig,
+		Blocks:         [][]string{},
+		Base:           ExampleConfig,
 	}
 }

--- a/pkg/connector/thread_resolver_db.go
+++ b/pkg/connector/thread_resolver_db.go
@@ -47,7 +47,7 @@ func (r *DBThreadMetadataResolver) ResolveThreadID(receiver, messageID string) (
 	// Use single UNION query to check all possible table/column combinations efficiently
 	// Try both raw and namespaced remote IDs to be robust
 	candidates := []string{mid, "email:" + mid}
-	
+
 	// Build single query that tries all combinations with UNION
 	unionQuery := `
 		SELECT portal_id, 'message_with_receiver' as source FROM message 
@@ -62,7 +62,7 @@ func (r *DBThreadMetadataResolver) ResolveThreadID(receiver, messageID string) (
 		SELECT portal_id, 'messages_no_receiver' as source FROM messages 
 		WHERE network = ? AND remote_id = ?
 		LIMIT 1`
-		
+
 	for _, rid := range candidates {
 		if result := r.queryUnionResult(ctx, unionQuery, r.Network, rid, receiver, r.Network, rid, r.Network, rid, receiver, r.Network, rid); result != "" {
 			ntid := normalizeThreadID(result)
@@ -90,7 +90,7 @@ func (r *DBThreadMetadataResolver) queryUnionResult(ctx context.Context, sql str
 		return ""
 	}
 	defer rows.Close()
-	
+
 	if rows.Next() {
 		var portalID, source string
 		if err := rows.Scan(&portalID, &source); err == nil {
@@ -108,7 +108,6 @@ func (r *DBThreadMetadataResolver) queryUnionResult(ctx context.Context, sql str
 	}
 	return ""
 }
-
 
 func normalizeThreadID(portalOrThreadID string) string {
 	id := strings.TrimSpace(portalOrThreadID)

--- a/pkg/coordinator/state_coordinator.go
+++ b/pkg/coordinator/state_coordinator.go
@@ -4,9 +4,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rs/zerolog"
 	"maunium.net/go/mautrix/bridgev2"
 	"maunium.net/go/mautrix/bridgev2/status"
-	"github.com/rs/zerolog"
 )
 
 // Error codes used by the state coordinator
@@ -18,12 +18,12 @@ var (
 
 // ConnectionEvent represents events about connection state changes
 type ConnectionEvent struct {
-	Component   string    // "inbox", "sent", "circuit_breaker"
-	Event       EventType
-	Connected   bool
-	Error       status.BridgeStateErrorCode
-	Metadata    map[string]any
-	Timestamp   time.Time
+	Component string // "inbox", "sent", "circuit_breaker"
+	Event     EventType
+	Connected bool
+	Error     status.BridgeStateErrorCode
+	Metadata  map[string]any
+	Timestamp time.Time
 }
 
 // EventType defines the types of events the coordinator can receive
@@ -31,56 +31,56 @@ type EventType string
 
 const (
 	// Connection lifecycle events
-	EventConnectionStarted    EventType = "connection_started"
+	EventConnectionStarted     EventType = "connection_started"
 	EventConnectionEstablished EventType = "connection_established"
-	EventConnectionLost       EventType = "connection_lost"
-	EventConnectionClosed     EventType = "connection_closed"
-	
+	EventConnectionLost        EventType = "connection_lost"
+	EventConnectionClosed      EventType = "connection_closed"
+
 	// IDLE specific events
-	EventIdleStarted          EventType = "idle_started"
-	EventIdleFailed           EventType = "idle_failed"
-	EventIdleRecovered        EventType = "idle_recovered"
-	
+	EventIdleStarted   EventType = "idle_started"
+	EventIdleFailed    EventType = "idle_failed"
+	EventIdleRecovered EventType = "idle_recovered"
+
 	// Circuit breaker events
-	EventCircuitOpened        EventType = "circuit_opened"
-	EventCircuitClosed        EventType = "circuit_closed"
-	EventCircuitHalfOpen      EventType = "circuit_half_open"
-	
+	EventCircuitOpened   EventType = "circuit_opened"
+	EventCircuitClosed   EventType = "circuit_closed"
+	EventCircuitHalfOpen EventType = "circuit_half_open"
+
 	// Health monitoring events
-	EventHealthCheckPassed    EventType = "health_check_passed"
-	EventHealthCheckFailed    EventType = "health_check_failed"
-	
+	EventHealthCheckPassed EventType = "health_check_passed"
+	EventHealthCheckFailed EventType = "health_check_failed"
+
 	// Authentication events
-	EventAuthSuccess          EventType = "auth_success"
-	EventAuthFailure          EventType = "auth_failure"
+	EventAuthSuccess EventType = "auth_success"
+	EventAuthFailure EventType = "auth_failure"
 )
 
 // ConnectionState tracks the state of individual connections
 type ConnectionState struct {
-	Connected     bool
-	IdleRunning   bool
-	LastEvent     EventType
-	LastError     status.BridgeStateErrorCode
-	LastUpdate    time.Time
-	FailureCount  int
+	Connected    bool
+	IdleRunning  bool
+	LastEvent    EventType
+	LastError    status.BridgeStateErrorCode
+	LastUpdate   time.Time
+	FailureCount int
 }
 
 // StateCoordinator centralizes all bridge state management
 type StateCoordinator struct {
-	mu           sync.RWMutex
-	login        *bridgev2.UserLogin
-	log          *zerolog.Logger
-	
+	mu    sync.RWMutex
+	login *bridgev2.UserLogin
+	log   *zerolog.Logger
+
 	// Connection states
 	inbox        ConnectionState
 	sent         ConnectionState
 	circuitState string
-	
+
 	// Current bridge state
 	currentState status.BridgeStateEvent
 	currentError status.BridgeStateErrorCode
 	lastSent     time.Time
-	
+
 	// State throttling
 	throttleDuration time.Duration
 }
@@ -89,9 +89,9 @@ type StateCoordinator struct {
 func NewStateCoordinator(login *bridgev2.UserLogin, log *zerolog.Logger) *StateCoordinator {
 	return &StateCoordinator{
 		login:            login,
-		log:             log,
-		circuitState:    "closed",
-		currentState:    status.StateStarting,
+		log:              log,
+		circuitState:     "closed",
+		currentState:     status.StateStarting,
 		throttleDuration: 30 * time.Second, // Reduced from 60s for more responsive updates
 	}
 }
@@ -100,19 +100,19 @@ func NewStateCoordinator(login *bridgev2.UserLogin, log *zerolog.Logger) *StateC
 func (sc *StateCoordinator) ReportEvent(event ConnectionEvent) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
-	
+
 	sc.log.Debug().
 		Str("component", event.Component).
 		Str("event", string(event.Event)).
 		Bool("connected", event.Connected).
 		Msg("State coordinator received event")
-	
+
 	// Update component state
 	sc.updateComponentState(event)
-	
+
 	// Compute new bridge state
 	newState, newError := sc.computeBridgeState()
-	
+
 	// Send bridge state if changed or throttle period expired
 	if sc.shouldSendState(newState, newError) {
 		sc.sendBridgeState(newState, newError, event.Metadata)
@@ -122,13 +122,13 @@ func (sc *StateCoordinator) ReportEvent(event ConnectionEvent) {
 // updateComponentState updates the internal state based on the event
 func (sc *StateCoordinator) updateComponentState(event ConnectionEvent) {
 	now := time.Now()
-	
+
 	switch event.Component {
 	case "inbox":
 		sc.inbox.LastEvent = event.Event
 		sc.inbox.LastUpdate = now
 		sc.inbox.LastError = event.Error
-		
+
 		switch event.Event {
 		case EventConnectionStarted:
 			// Starting connection process
@@ -147,12 +147,12 @@ func (sc *StateCoordinator) updateComponentState(event ConnectionEvent) {
 			sc.inbox.IdleRunning = true
 			sc.inbox.FailureCount = 0
 		}
-		
+
 	case "sent":
 		sc.sent.LastEvent = event.Event
 		sc.sent.LastUpdate = now
 		sc.sent.LastError = event.Error
-		
+
 		switch event.Event {
 		case EventConnectionStarted:
 			// Starting connection process
@@ -171,7 +171,7 @@ func (sc *StateCoordinator) updateComponentState(event ConnectionEvent) {
 			sc.sent.IdleRunning = true
 			sc.sent.FailureCount = 0
 		}
-		
+
 	case "circuit_breaker":
 		switch event.Event {
 		case EventCircuitOpened:
@@ -190,7 +190,7 @@ func (sc *StateCoordinator) computeBridgeState() (status.BridgeStateEvent, statu
 	if sc.circuitState == "open" {
 		return status.StateBridgeUnreachable, EmailCircuitOpen
 	}
-	
+
 	// No INBOX connection = bridge unreachable
 	if !sc.inbox.Connected {
 		if sc.inbox.LastError != "" {
@@ -198,7 +198,7 @@ func (sc *StateCoordinator) computeBridgeState() (status.BridgeStateEvent, statu
 		}
 		return status.StateBridgeUnreachable, EmailConnectionFailed
 	}
-	
+
 	// INBOX connected but IDLE not running = transient disconnect
 	if sc.inbox.Connected && !sc.inbox.IdleRunning {
 		if sc.inbox.LastError != "" {
@@ -206,14 +206,14 @@ func (sc *StateCoordinator) computeBridgeState() (status.BridgeStateEvent, statu
 		}
 		return status.StateTransientDisconnect, EmailIdleFailed
 	}
-	
+
 	// INBOX fully functional
 	if sc.inbox.Connected && sc.inbox.IdleRunning {
 		// Sent connection failure is noted but doesn't demote bridge state
 		// (INBOX functionality is sufficient for basic operation)
 		return status.StateConnected, ""
 	}
-	
+
 	// Fallback: starting state
 	return status.StateStarting, ""
 }
@@ -224,12 +224,12 @@ func (sc *StateCoordinator) shouldSendState(newState status.BridgeStateEvent, ne
 	if newState != sc.currentState || newError != sc.currentError {
 		return true
 	}
-	
+
 	// Send periodic updates if throttle period expired
 	if time.Since(sc.lastSent) > sc.throttleDuration {
 		return true
 	}
-	
+
 	return false
 }
 
@@ -238,7 +238,7 @@ func (sc *StateCoordinator) sendBridgeState(newState status.BridgeStateEvent, ne
 	if sc.login == nil {
 		return
 	}
-	
+
 	// Build info map with connection details
 	info := make(map[string]any)
 	if metadata != nil {
@@ -246,7 +246,7 @@ func (sc *StateCoordinator) sendBridgeState(newState status.BridgeStateEvent, ne
 			info[k] = v
 		}
 	}
-	
+
 	// Add connection health information
 	info["inbox_connected"] = sc.inbox.Connected
 	info["inbox_idle_running"] = sc.inbox.IdleRunning
@@ -254,7 +254,7 @@ func (sc *StateCoordinator) sendBridgeState(newState status.BridgeStateEvent, ne
 	info["sent_idle_running"] = sc.sent.IdleRunning
 	info["circuit_breaker_state"] = sc.circuitState
 	info["coordinator_update"] = time.Now().Format(time.RFC3339)
-	
+
 	// Add failure counts for debugging
 	if sc.inbox.FailureCount > 0 {
 		info["inbox_failure_count"] = sc.inbox.FailureCount
@@ -262,25 +262,25 @@ func (sc *StateCoordinator) sendBridgeState(newState status.BridgeStateEvent, ne
 	if sc.sent.FailureCount > 0 {
 		info["sent_failure_count"] = sc.sent.FailureCount
 	}
-	
+
 	bridgeState := status.BridgeState{
 		StateEvent: newState,
 		Info:       info,
 	}
-	
+
 	if newError != "" {
 		bridgeState.Error = newError
 	}
-	
+
 	sc.log.Info().
 		Str("state", string(newState)).
 		Str("error", string(newError)).
 		Bool("inbox_connected", sc.inbox.Connected).
 		Bool("sent_connected", sc.sent.Connected).
 		Msg("State coordinator sending bridge state")
-	
+
 	sc.login.BridgeState.Send(bridgeState)
-	
+
 	// Update tracking
 	sc.currentState = newState
 	sc.currentError = newError
@@ -299,7 +299,7 @@ func (sc *StateCoordinator) ReportSimpleEvent(component string, event string, co
 		Metadata:  metadata,
 		Timestamp: time.Now(),
 	}
-	
+
 	// Call the main ReportEvent method
 	sc.ReportEvent(connectionEvent)
 }

--- a/pkg/imap/manager.go
+++ b/pkg/imap/manager.go
@@ -76,7 +76,7 @@ func (m *Manager) AddAccount(login *bridgev2.UserLogin, email, username, passwor
 	logger := m.log.With().
 		Str("user", login.UserMXID.String()).
 		Str("email", email).Logger()
-client, err := NewClient(email, username, password, login, &logger, m.sanitized, m.secret, 180, 25, 3, nil)
+client, err := NewClient(email, username, password, nil, login, &logger, m.sanitized, m.secret, 180, 25, 3, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create IMAP client: %w", err)
 	}

--- a/pkg/logging/sanitize.go
+++ b/pkg/logging/sanitize.go
@@ -125,4 +125,3 @@ func max(a, b int) int {
 	}
 	return b
 }
-

--- a/pkg/matrix/room_manager.go
+++ b/pkg/matrix/room_manager.go
@@ -12,8 +12,8 @@ import (
 	"maunium.net/go/mautrix/bridgev2/networkid"
 	"maunium.net/go/mautrix/event"
 
-	"github.com/iFixRobots/emaildawg/pkg/email"
 	"github.com/iFixRobots/emaildawg/pkg/common"
+	"github.com/iFixRobots/emaildawg/pkg/email"
 )
 
 // RoomManager handles Matrix room creation and management for email threads
@@ -108,7 +108,7 @@ func (rm *RoomManager) GetChatInfoForThread(ctx context.Context, thread *email.E
 		Int("member_count", len(memberMap)).
 		Msg("Created ChatInfo for email thread")
 
-return chatInfo, nil
+	return chatInfo, nil
 }
 
 // BuildReadOnlyPowerLevels centralizes the power level configuration for email threads.
@@ -128,10 +128,10 @@ func BuildReadOnlyPowerLevels() *bridgev2.PowerLevelOverrides {
 			event.StateTopic:      101,
 			event.StateRoomAvatar: 101,
 			// Block all users from sending messages - bridge framework handles ghost sending
-			event.EventMessage:    101,
+			event.EventMessage: 101,
 			// Keep reactions/redactions restricted to prevent Matrix-side edits by default
-			event.EventReaction:   101,
-			event.EventRedaction:  101,
+			event.EventReaction:  101,
+			event.EventRedaction: 101,
 		},
 	}
 }
@@ -141,7 +141,7 @@ func (rm *RoomManager) formatRoomName(subject string) string {
 	// Remove common email prefixes
 	subject = strings.TrimSpace(subject)
 	prefixes := []string{"Re: ", "RE: ", "Fwd: ", "FWD: ", "Fw: ", "FW: "}
-	
+
 	for {
 		trimmed := false
 		for _, prefix := range prefixes {
@@ -155,22 +155,18 @@ func (rm *RoomManager) formatRoomName(subject string) string {
 			break
 		}
 	}
-	
+
 	// Limit length and clean up
 	if len(subject) > 80 {
 		subject = subject[:77] + "..."
 	}
-	
+
 	if subject == "" {
 		subject = "Email Thread"
 	}
-	
+
 	return subject
 }
-
-
-
-
 
 // Note: UpdateRoomParticipants and SendEmailMessage will be handled by the EmailConnector
 // using the bridgev2 framework's built-in room and message management capabilities.

--- a/pkg/reliability/timeout.go
+++ b/pkg/reliability/timeout.go
@@ -14,12 +14,12 @@ type Logger interface {
 
 // TimeoutConfig holds timeout settings for different operations
 type TimeoutConfig struct {
-	Connect    time.Duration
-	Read       time.Duration
-	Write      time.Duration
-	Idle       time.Duration
-	Command    time.Duration
-	Total      time.Duration
+	Connect time.Duration
+	Read    time.Duration
+	Write   time.Duration
+	Idle    time.Duration
+	Command time.Duration
+	Total   time.Duration
 }
 
 // DefaultTimeouts returns sensible default timeouts
@@ -38,9 +38,9 @@ func DefaultTimeouts() TimeoutConfig {
 func IMAPTimeouts() TimeoutConfig {
 	return TimeoutConfig{
 		Connect: 45 * time.Second,
-		Read:    120 * time.Second,  // IMAP can be slow
+		Read:    120 * time.Second, // IMAP can be slow
 		Write:   60 * time.Second,
-		Idle:    30 * time.Minute,   // IDLE can run long
+		Idle:    30 * time.Minute, // IDLE can run long
 		Command: 45 * time.Second,
 		Total:   15 * time.Minute,
 	}
@@ -51,7 +51,7 @@ func IMAPTimeouts() TimeoutConfig {
 // Callers must ensure fn() checks ctx.Done() periodically to avoid resource leaks.
 func runWithCtx(ctx context.Context, logger Logger, fn func(context.Context) error) error {
 	done := make(chan error, 1)
-	
+
 	go func() {
 		defer func() {
 			// Recover from any panic in fn to prevent goroutine leak
@@ -66,7 +66,7 @@ func runWithCtx(ctx context.Context, logger Logger, fn func(context.Context) err
 				}
 			}
 		}()
-		
+
 		// Execute function and send result (non-blocking to prevent goroutine leak)
 		err := fn(ctx)
 		select {
@@ -77,7 +77,7 @@ func runWithCtx(ctx context.Context, logger Logger, fn func(context.Context) err
 			// This is expected behavior when function completes after timeout
 		}
 	}()
-	
+
 	select {
 	case err := <-done:
 		return err
@@ -98,7 +98,7 @@ func WithTimeout(parentCtx context.Context, timeout time.Duration, logger Logger
 	return runWithCtx(ctx, logger, fn)
 }
 
-// WithDeadline executes a function with a deadline  
+// WithDeadline executes a function with a deadline
 func WithDeadline(parentCtx context.Context, deadline time.Time, logger Logger, fn func(ctx context.Context) error) error {
 	ctx, cancel := context.WithDeadline(parentCtx, deadline)
 	defer cancel()


### PR DESCRIPTION
## Summary

- add an optional IMAP host override field to the login flow and CLI so Gmail-hosted custom domains (e.g. alaq.io on imap.gmail.com) can be configured explicitly instead of guessing imap.<domain>
- persist the override and reuse it when building IMAP clients, with logging/help messaging updated to highlight the option
- detect the provider from either the email domain or the supplied host, so we pick the right defaults (including the Gmail sent-folder [Gmail]/Sent Mail) for hosted domains

## Testing

- gofmt on touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Manual IMAP server overrides during login (host/port/TLS). Supports an optional imap_host parameter and updated prompts. Sent folder detection now respects custom hosts.
- Improvements
  - More resilient IMAP connectivity: smarter auto-reconnect and IDLE restart, enhanced state tracking, and clearer circuit breaker behavior (allows a test request in half-open).
  - Safer, slightly more robust email processing.
  - Retry/backoff now validates configs, respects cancellation, and applies sensible delay floors on throttling.
- Documentation
  - Login instructions updated to include the manual IMAP server option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->